### PR TITLE
Protected attributes

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -5,6 +5,7 @@ class Api::AuthController < ApplicationController
   def authenticate
     user = User.find_by_credentials(params[:username], params[:password])
     if user
+      @current_user = user
       render json: { auth_token: user.generate_auth_token }
     else
       render json: { error: 'Invalid username or password' }, status: :unauthorized
@@ -13,17 +14,18 @@ class Api::AuthController < ApplicationController
 
   def authenticate_commenter
     commenter = Commenter.find_by_email(params[:email])
-    unless commenter
+    unless commenter.present?
       commenter = Commenter.create!(name: params[:username], email: params[:email])
     end
-    if commenter
+    if commenter.present?
+      @current_user = commenter
+      render json: { auth_token: commenter.generate_auth_token }
       render json: { auth_token: commenter.generate_auth_token, commenter_id: commenter.id }
     else
       render json: { error: 'Invalid name or email' }, status: :unauthorized
     end
-  rescue => e
-    byebug
-    render json: { error: 'Could not create or authenticate user'}, status: :unauthorized
+  rescue Exception => e
+    render json: { error: e.message }, status: :unauthorized
   end
 
   private

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -1,14 +1,25 @@
 class Api::V1::CommentsController < ApiControllerController
   skip_before_action :set_current_user, :authenticate_request, only: [:index, :show, :show_association, :get_related_resources]
+  before_action :set_current_user
+
+  def current_user
+    @current_user
+  end
 
   private
 
+    def context
+      self
+    end
+
     def set_current_user
       if decoded_auth_token
-        @current_user ||= Commenter.find(decoded_auth_token[:commenter_id])
-        unless @current_user
-          @current_user ||= User.find(decoded_auth_token[:user_id])
+        if decoded_auth_token.has_key? :commenter_id
+          @current_user = Commenter.find(decoded_auth_token[:commenter_id])
+        elsif decoded_auth_token.has_key? :user_id
+          @current_user = User.find(decoded_auth_token[:user_id])
         end
+        nil
       end
     end
 

--- a/app/controllers/api_controller_controller.rb
+++ b/app/controllers/api_controller_controller.rb
@@ -10,6 +10,10 @@ class ApiControllerController < JSONAPI::ResourceController
     render json: { error: 'Auth token is expired' }, status: 419 # unofficial timeout status code
   end
 
+  def current_user
+    @current_user
+  end
+
   private
 
   # Based on the user_id inside the token payload, find the user.

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,4 +3,6 @@ class Comment < ActiveRecord::Base
   belongs_to :post
 
   validates :body, :length => { :minimum => 2 }
+
+  scope :approved, -> { where(approved: true) }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,6 @@
 class Post < ActiveRecord::Base
   belongs_to :author
-  has_many :comments
+  has_many :comments, -> { where(approved: true) }
 
   validates :slug, uniqueness: true
 

--- a/app/resources/api/v1/comment_resource.rb
+++ b/app/resources/api/v1/comment_resource.rb
@@ -1,7 +1,40 @@
 require 'jsonapi/resource'
 
 class Api::V1::CommentResource < JSONAPI::Resource
-  attributes :id, :body, :approved, :created_at
+  attributes :id, :body, :created_at
+  attribute :approved
   has_one :commenter
   has_one :post
+
+  def approved
+    if user_is_authorized or comment_owned_by_commenter?(@model)
+      return @model.approved
+    end
+  end
+
+  def fetchable_fields
+    user_is_known ? super : super - [:approved]
+  end
+
+  private
+
+    def current_user
+      context.respond_to?(:current_user) ? context.current_user : nil
+    end
+
+    def user_is_commenter
+      current_user.present? and current_user.is_a? Commenter
+    end
+
+    def user_is_authorized
+      current_user.present? and current_user.is_a? User
+    end
+
+    def user_is_known
+      user_is_commenter or user_is_authorized
+    end
+
+    def comment_owned_by_commenter?(model)
+      user_is_commenter and model.commenter.id == current_user.id
+    end
 end


### PR DESCRIPTION
The 'approved' attribute of a Comment resource is protected, A Commenter may see the approved (status) value of their own Comments; but not the approved status of another Commenter's Comments. A User (the admin/moderate) sees the approved (status) of all Comments. A visitor (w/o valid Authorization header) does not see the 'protected' hash that contains the 'approved' attribute and value.